### PR TITLE
fixed code example in readme file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 ```javascript
 var mtg = require('mtg');
 mtg.download(function () {
-    mtg.json2db(function () {
+    mtg.json2db("mongodb://localhost/mtg", function () {
         console.log('done');
     });
 });


### PR DESCRIPTION
`json2db()` expects a connection string as first argument. fixed the code example in README accordingly.
